### PR TITLE
Handle if issuerInt is missing

### DIFF
--- a/backup_freetop_codes.py
+++ b/backup_freetop_codes.py
@@ -34,7 +34,7 @@ for token in xmltree.findall('string'):
               'digits': token["digits"],
               'period': token["period"],
               'counter': token["counter"],
-              'issuer': token["issuerInt"]
+              'issuer': token.get("issuerInt", token["issuerExt"])
               }
     paramsStr = '&'.join([f'{k}={v}' for (k, v) in params.items()])
     url = f'otpauth://totp/{issuerExt}:{label}?{paramsStr}'


### PR DESCRIPTION
I bumped into the following error when I used your script - thank you for this handy tool! After some digging this fix seems a valid solution to the problem.

```python
Traceback (most recent call last):
  File "backup_freetop_codes.py", line 37, in <module>
    'issuer': token["issuerInt"]
KeyError: 'issuerInt'
```